### PR TITLE
Cache object may be passed into RootContainer

### DIFF
--- a/cache.es6
+++ b/cache.es6
@@ -1,0 +1,16 @@
+
+/* global serverCache */
+const hydrateCache = typeof serverCache !== 'undefined' ? serverCache : {};
+export const cacheStorage = { ...hydrateCache };
+
+export default function cache(key) {
+  return {
+    get: function get() {
+      return cacheStorage[key];
+    },
+    set: function set(value) {
+      cacheStorage[key] = value;
+      return this;
+    },
+  };
+}

--- a/cache.es6
+++ b/cache.es6
@@ -1,4 +1,3 @@
-
 /* global serverCache */
 const hydrateCache = typeof serverCache !== 'undefined' ? serverCache : {};
 export const cacheStorage = { ...hydrateCache };

--- a/example.es6
+++ b/example.es6
@@ -4,6 +4,15 @@ import cache from './cache';
 import fetch from './fetch';
 import Impart from '.';
 
+cache('/article/1').set({
+  style: {
+    color: 'white',
+    backgroundColor: 'black',
+  },
+  title: 'cached title',
+  text: 'cached text',
+});
+
 class MyAppComponent extends React.Component {
   doSomething() {
     console.log('You clicked'); // eslint-disable-line
@@ -20,6 +29,7 @@ class MyAppComponent extends React.Component {
 
 export default (
   <Impart.RootContainer
+    articleId={1}
     Component={MyAppComponent}
     cache={({ articleId }) => (cache(`/article/${articleId}`))}
     route={({ articleId }) => (fetch(`http://url/to/resource/${articleId}`))}

--- a/example.es6
+++ b/example.es6
@@ -1,4 +1,6 @@
+/* eslint-disable react/no-multi-comp, react/display-name */
 import React from 'react';
+import cache from './cache';
 import fetch from './fetch';
 import Impart from '.';
 
@@ -19,6 +21,7 @@ class MyAppComponent extends React.Component {
 export default (
   <Impart.RootContainer
     Component={MyAppComponent}
+    cache={({ articleId }) => (cache(`/article/${articleId}`))}
     route={({ articleId }) => (fetch(`http://url/to/resource/${articleId}`))}
     renderLoading={() => (<div>Loading...</div>)}
     renderFailure={(error) => (<div>Error: {error.message}</div>)}

--- a/index.es6
+++ b/index.es6
@@ -32,8 +32,10 @@ class RootContainer extends React.Component {
   loadCache() {
     const { cache, ...remainingProps } = this.props;
     if (cache) {
-      const cacheData = cache(remainingProps).get() || {};
-      this.setState({ data: cacheData, readyState: 'cached' });
+      const cacheData = cache(remainingProps).get();
+      if (cacheData) {
+        this.setState({ data: cacheData, readyState: 'cached' });
+      }
     }
   }
 
@@ -61,7 +63,7 @@ class RootContainer extends React.Component {
       if (renderFailure) {
         children = renderFailure(data);
       }
-    } else if (data && readyState === 'fetched') {
+    } else if (data && (readyState === 'fetched' || readyState === 'cached')) {
       if (renderFetched) {
         children = renderFetched(data);
       } else {

--- a/test/index.es6
+++ b/test/index.es6
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp, react/display-name */
 import React from 'react';
 import chai from 'chai';
 import Impart from '../.';


### PR DESCRIPTION
Cache object may be passed into RootContainer.

See also:

1. https://github.com/economist-components/component-win-app/pull/23
2. https://github.com/the-economist-editorial/win-website/pull/31